### PR TITLE
chore: handled env in a different way

### DIFF
--- a/apps/client/app/components/footer/index.tsx
+++ b/apps/client/app/components/footer/index.tsx
@@ -1,15 +1,15 @@
-import { Fragment } from 'react'
+import {Fragment} from 'react'
 import {
   GITHUB_REPO_URL,
   MYLES_PUDO_URL,
   TWITTER_ACCOUNT_URL,
 } from '@/constants/index.ts'
-import { type JSX } from 'react/jsx-runtime'
-import { Link } from '@remix-run/react'
+import {type JSX} from 'react/jsx-runtime'
+import {Link} from '@remix-run/react'
 
 const insideNavigation = [
-  { name: 'Pricing', href: '/#pricing'},
-  { name: 'Terms Of Use', href: '/terms'},
+  {name: 'Pricing', href: '/#pricing'},
+  {name: 'Terms Of Use', href: '/terms'},
 ]
 
 const navigation = [
@@ -100,20 +100,18 @@ export const Footer = () => {
           </div>
 
           <div className="flex gap-3 items-center">
-            {
-              insideNavigation.map((item, index) => {
-                return (
-                  <Fragment key={index}>
-                      <Link
-                        to={item.href}
-                        className="text-sm font-semibold leading-6 text-gray-400 hover:text-gray-500"
-                      >
-                        {item.name}
-                      </Link>
-                  </Fragment>
-                )
-              })
-            }
+            {insideNavigation.map((item, index) => {
+              return (
+                <Fragment key={index}>
+                  <Link
+                    to={item.href}
+                    className="text-sm font-semibold leading-6 text-gray-400 hover:text-gray-500"
+                  >
+                    {item.name}
+                  </Link>
+                </Fragment>
+              )
+            })}
           </div>
         </div>
       </div>

--- a/apps/client/app/lib/transport/index.ts
+++ b/apps/client/app/lib/transport/index.ts
@@ -5,7 +5,6 @@ declare global {
   interface Window {
     ENV: {
       API_ADDRESS: string
-      BUCKET: string
     }
   }
 }

--- a/apps/client/app/modules/auth/login/facebook/index.tsx
+++ b/apps/client/app/modules/auth/login/facebook/index.tsx
@@ -1,14 +1,15 @@
 /* eslint-disable func-names */
-import {useAuthenticate} from '@/api/auth/index.ts'
-import {Button} from '@/components/button/index.tsx'
-import {useLoaderData, useNavigate} from '@remix-run/react'
-import {useEffect} from 'react'
-import {useLoginAuth} from '../context/index.tsx'
-import {errorMessagesWrapper} from '@/constants/error-messages.ts'
-import {toast} from 'react-hot-toast'
-import {useAuth} from '@/providers/auth/index.tsx'
-import {useQueryClient} from '@tanstack/react-query'
-import {QUERY_KEYS} from '@/constants/index.ts'
+import { useAuthenticate } from '@/api/auth/index.ts'
+import { Button } from '@/components/button/index.tsx'
+import { useNavigate } from '@remix-run/react'
+import { useEffect } from 'react'
+import { useLoginAuth } from '../context/index.tsx'
+import { errorMessagesWrapper } from '@/constants/error-messages.ts'
+import { toast } from 'react-hot-toast'
+import { useAuth } from '@/providers/auth/index.tsx'
+import { useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from '@/constants/index.ts'
+import { useEnvContext } from '@/providers/env/index.tsx'
 
 declare global {
   interface Window {
@@ -19,33 +20,33 @@ declare global {
 }
 
 export const FacebookButton = () => {
-  const data = useLoaderData<{FACEBOOK_APP_ID: string}>()
 
-  const {mutate} = useAuthenticate()
-  const {setIsLoading, setErrorMessage} = useLoginAuth()
-  const {onSignin} = useAuth()
+  const { mutate } = useAuthenticate()
+  const { setIsLoading, setErrorMessage } = useLoginAuth()
+  const { onSignin } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const env = useEnvContext()
 
   useEffect(() => {
     window.fbAsyncInit = function () {
       window.FB.init({
-        appId: data.FACEBOOK_APP_ID,
+        appId: env.FACEBOOK_APP_ID,
         autoLogAppEvents: true,
         xfbml: true,
         version: 'v10.0',
       })
     }
-    ;(function (d, s, id) {
-      let js: any = d.getElementsByTagName(s)[0]
-      const fjs: any = d.getElementsByTagName(s)[0]
-      if (d.getElementById(id)) return
-      js = d.createElement(s)
-      js.id = id
-      js.src = 'https://connect.facebook.net/en_US/sdk.js'
-      fjs.parentNode.insertBefore(js, fjs)
-    })(document, 'script', 'facebook-jssdk')
-  }, [data.FACEBOOK_APP_ID])
+      ; (function (d, s, id) {
+        let js: any = d.getElementsByTagName(s)[0]
+        const fjs: any = d.getElementsByTagName(s)[0]
+        if (d.getElementById(id)) return
+        js = d.createElement(s)
+        js.id = id
+        js.src = 'https://connect.facebook.net/en_US/sdk.js'
+        fjs.parentNode.insertBefore(js, fjs)
+      })(document, 'script', 'facebook-jssdk')
+  }, [])
 
   const handleLogin = (res: any) => {
     setIsLoading(true)
@@ -94,7 +95,7 @@ export const FacebookButton = () => {
             (loginResponse: any) => {
               handleLogin(loginResponse)
             },
-            {scope: 'public_profile,email'},
+            { scope: 'public_profile,email' },
           )
         }
       })

--- a/apps/client/app/modules/auth/login/facebook/index.tsx
+++ b/apps/client/app/modules/auth/login/facebook/index.tsx
@@ -1,15 +1,15 @@
 /* eslint-disable func-names */
-import { useAuthenticate } from '@/api/auth/index.ts'
-import { Button } from '@/components/button/index.tsx'
-import { useNavigate } from '@remix-run/react'
-import { useEffect } from 'react'
-import { useLoginAuth } from '../context/index.tsx'
-import { errorMessagesWrapper } from '@/constants/error-messages.ts'
-import { toast } from 'react-hot-toast'
-import { useAuth } from '@/providers/auth/index.tsx'
-import { useQueryClient } from '@tanstack/react-query'
-import { QUERY_KEYS } from '@/constants/index.ts'
-import { useEnvContext } from '@/providers/env/index.tsx'
+import {useAuthenticate} from '@/api/auth/index.ts'
+import {Button} from '@/components/button/index.tsx'
+import {useNavigate} from '@remix-run/react'
+import {useEffect} from 'react'
+import {useLoginAuth} from '../context/index.tsx'
+import {errorMessagesWrapper} from '@/constants/error-messages.ts'
+import {toast} from 'react-hot-toast'
+import {useAuth} from '@/providers/auth/index.tsx'
+import {useQueryClient} from '@tanstack/react-query'
+import {QUERY_KEYS} from '@/constants/index.ts'
+import {useEnvContext} from '@/providers/env/index.tsx'
 
 declare global {
   interface Window {
@@ -20,10 +20,9 @@ declare global {
 }
 
 export const FacebookButton = () => {
-
-  const { mutate } = useAuthenticate()
-  const { setIsLoading, setErrorMessage } = useLoginAuth()
-  const { onSignin } = useAuth()
+  const {mutate} = useAuthenticate()
+  const {setIsLoading, setErrorMessage} = useLoginAuth()
+  const {onSignin} = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const env = useEnvContext()
@@ -37,15 +36,15 @@ export const FacebookButton = () => {
         version: 'v10.0',
       })
     }
-      ; (function (d, s, id) {
-        let js: any = d.getElementsByTagName(s)[0]
-        const fjs: any = d.getElementsByTagName(s)[0]
-        if (d.getElementById(id)) return
-        js = d.createElement(s)
-        js.id = id
-        js.src = 'https://connect.facebook.net/en_US/sdk.js'
-        fjs.parentNode.insertBefore(js, fjs)
-      })(document, 'script', 'facebook-jssdk')
+    ;(function (d, s, id) {
+      let js: any = d.getElementsByTagName(s)[0]
+      const fjs: any = d.getElementsByTagName(s)[0]
+      if (d.getElementById(id)) return
+      js = d.createElement(s)
+      js.id = id
+      js.src = 'https://connect.facebook.net/en_US/sdk.js'
+      fjs.parentNode.insertBefore(js, fjs)
+    })(document, 'script', 'facebook-jssdk')
   }, [])
 
   const handleLogin = (res: any) => {
@@ -95,7 +94,7 @@ export const FacebookButton = () => {
             (loginResponse: any) => {
               handleLogin(loginResponse)
             },
-            { scope: 'public_profile,email' },
+            {scope: 'public_profile,email'},
           )
         }
       })

--- a/apps/client/app/modules/auth/login/google/index.tsx
+++ b/apps/client/app/modules/auth/login/google/index.tsx
@@ -1,14 +1,15 @@
-import {useAuthenticate} from '@/api/auth/index.ts'
-import {useBreakpoint} from '@/hooks/tailwind.ts'
-import {isBrowser} from '@/lib/is-browser.ts'
-import {useLoaderData, useNavigate} from '@remix-run/react'
-import {useCallback, useEffect, useRef} from 'react'
-import {useLoginAuth} from '../context/index.tsx'
-import {errorMessagesWrapper} from '@/constants/error-messages.ts'
-import {toast} from 'react-hot-toast'
-import {useAuth} from '@/providers/auth/index.tsx'
-import {useQueryClient} from '@tanstack/react-query'
-import {QUERY_KEYS} from '@/constants/index.ts'
+import { useAuthenticate } from '@/api/auth/index.ts'
+import { useBreakpoint } from '@/hooks/tailwind.ts'
+import { isBrowser } from '@/lib/is-browser.ts'
+import { useNavigate } from '@remix-run/react'
+import { useCallback, useEffect, useRef } from 'react'
+import { useLoginAuth } from '../context/index.tsx'
+import { errorMessagesWrapper } from '@/constants/error-messages.ts'
+import { toast } from 'react-hot-toast'
+import { useAuth } from '@/providers/auth/index.tsx'
+import { useQueryClient } from '@tanstack/react-query'
+import { QUERY_KEYS } from '@/constants/index.ts'
+import { useEnvContext } from '@/providers/env/index.tsx'
 
 declare global {
   interface Window {
@@ -18,14 +19,14 @@ declare global {
 }
 
 export const GoogleButton = () => {
-  const {mutate} = useAuthenticate()
-  const {setIsLoading, setErrorMessage} = useLoginAuth()
-  const {onSignin} = useAuth()
+  const { mutate } = useAuthenticate()
+  const { setIsLoading, setErrorMessage } = useLoginAuth()
+  const { onSignin } = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
+  const env = useEnvContext()
 
   const signInRef = useRef(null)
-  const data = useLoaderData<{MFONI_GOOGLE_AUTH_CLIENT_ID: string}>()
   const isMobileBreakPoint = useBreakpoint('sm')
 
   const onLoginWithGoogle = useCallback(
@@ -75,7 +76,7 @@ export const GoogleButton = () => {
   const init = useCallback(() => {
     if (window.google) {
       window.google.accounts.id.initialize({
-        client_id: data.MFONI_GOOGLE_AUTH_CLIENT_ID,
+        client_id: env.MFONI_GOOGLE_AUTH_CLIENT_ID,
         callback: onLoginWithGoogle,
       })
 
@@ -89,7 +90,7 @@ export const GoogleButton = () => {
         width: isMobileBreakPoint ? '355' : '385',
       })
     }
-  }, [data.MFONI_GOOGLE_AUTH_CLIENT_ID, isMobileBreakPoint, onLoginWithGoogle])
+  }, [env.MFONI_GOOGLE_AUTH_CLIENT_ID, isMobileBreakPoint, onLoginWithGoogle])
 
   useEffect(() => {
     if (isBrowser) {

--- a/apps/client/app/modules/auth/login/google/index.tsx
+++ b/apps/client/app/modules/auth/login/google/index.tsx
@@ -1,15 +1,15 @@
-import { useAuthenticate } from '@/api/auth/index.ts'
-import { useBreakpoint } from '@/hooks/tailwind.ts'
-import { isBrowser } from '@/lib/is-browser.ts'
-import { useNavigate } from '@remix-run/react'
-import { useCallback, useEffect, useRef } from 'react'
-import { useLoginAuth } from '../context/index.tsx'
-import { errorMessagesWrapper } from '@/constants/error-messages.ts'
-import { toast } from 'react-hot-toast'
-import { useAuth } from '@/providers/auth/index.tsx'
-import { useQueryClient } from '@tanstack/react-query'
-import { QUERY_KEYS } from '@/constants/index.ts'
-import { useEnvContext } from '@/providers/env/index.tsx'
+import {useAuthenticate} from '@/api/auth/index.ts'
+import {useBreakpoint} from '@/hooks/tailwind.ts'
+import {isBrowser} from '@/lib/is-browser.ts'
+import {useNavigate} from '@remix-run/react'
+import {useCallback, useEffect, useRef} from 'react'
+import {useLoginAuth} from '../context/index.tsx'
+import {errorMessagesWrapper} from '@/constants/error-messages.ts'
+import {toast} from 'react-hot-toast'
+import {useAuth} from '@/providers/auth/index.tsx'
+import {useQueryClient} from '@tanstack/react-query'
+import {QUERY_KEYS} from '@/constants/index.ts'
+import {useEnvContext} from '@/providers/env/index.tsx'
 
 declare global {
   interface Window {
@@ -19,9 +19,9 @@ declare global {
 }
 
 export const GoogleButton = () => {
-  const { mutate } = useAuthenticate()
-  const { setIsLoading, setErrorMessage } = useLoginAuth()
-  const { onSignin } = useAuth()
+  const {mutate} = useAuthenticate()
+  const {setIsLoading, setErrorMessage} = useLoginAuth()
+  const {onSignin} = useAuth()
   const navigate = useNavigate()
   const queryClient = useQueryClient()
   const env = useEnvContext()

--- a/apps/client/app/modules/upload/context.tsx
+++ b/apps/client/app/modules/upload/context.tsx
@@ -14,6 +14,7 @@ import {
 } from '@/api/contents/index.ts'
 import {useNavigate} from '@remix-run/react'
 import {safeString} from '@/lib/strings.ts'
+import { useEnvContext } from '@/providers/env/index.tsx'
 
 // 30 MB
 const MAX_SIZE = 30
@@ -69,6 +70,7 @@ export const ContentUploadProvider = () => {
   const navigate = useNavigate()
   const [contents, setContents] = useState<ContentUploadContext['contents']>({})
   const {mutate, isPending} = useCreateContent()
+  const env = useEnvContext()
 
   const onDrop = useCallback(
     async (acceptedFiles: File[], fileRejections: FileRejection[]) => {
@@ -162,7 +164,7 @@ export const ContentUploadProvider = () => {
           content: {
             key: fileKey,
             location: safeString(content.filUploadedUrl),
-            bucket: window.ENV.BUCKET,
+            bucket: env.BUCKET,
             eTag: safeString(content.eTag),
             serverSideEncryption: 'AES256',
           },

--- a/apps/client/app/providers/env/index.tsx
+++ b/apps/client/app/providers/env/index.tsx
@@ -1,15 +1,15 @@
-import { createContext, useContext } from 'react'
+import {createContext, useContext} from 'react'
 
 interface IEnvContext {
-    BUCKET: string
-    MFONI_GOOGLE_AUTH_CLIENT_ID: string
-    FACEBOOK_APP_ID: string
+  BUCKET: string
+  MFONI_GOOGLE_AUTH_CLIENT_ID: string
+  FACEBOOK_APP_ID: string
 }
 
 export const EnvContext = createContext<IEnvContext>({
-    BUCKET: '',
-    MFONI_GOOGLE_AUTH_CLIENT_ID: '',
-    FACEBOOK_APP_ID: '',
+  BUCKET: '',
+  MFONI_GOOGLE_AUTH_CLIENT_ID: '',
+  FACEBOOK_APP_ID: '',
 })
 
 export const useEnvContext = () => useContext(EnvContext)

--- a/apps/client/app/providers/env/index.tsx
+++ b/apps/client/app/providers/env/index.tsx
@@ -1,0 +1,15 @@
+import { createContext, useContext } from 'react'
+
+interface IEnvContext {
+    BUCKET: string
+    MFONI_GOOGLE_AUTH_CLIENT_ID: string
+    FACEBOOK_APP_ID: string
+}
+
+export const EnvContext = createContext<IEnvContext>({
+    BUCKET: '',
+    MFONI_GOOGLE_AUTH_CLIENT_ID: '',
+    FACEBOOK_APP_ID: '',
+})
+
+export const useEnvContext = () => useContext(EnvContext)

--- a/apps/client/app/providers/index.tsx
+++ b/apps/client/app/providers/index.tsx
@@ -1,8 +1,8 @@
-import {type PropsWithChildren} from 'react'
-import {ReactQueryProvider} from './react-query/index.tsx'
-import {AuthProvider} from './auth/index.tsx'
+import { type PropsWithChildren } from 'react'
+import { ReactQueryProvider } from './react-query/index.tsx'
+import { AuthProvider } from './auth/index.tsx'
 
-export const Providers = ({children}: PropsWithChildren) => {
+export const Providers = ({ children }: PropsWithChildren) => {
   return (
     <ReactQueryProvider>
       <AuthProvider>{children}</AuthProvider>

--- a/apps/client/app/providers/index.tsx
+++ b/apps/client/app/providers/index.tsx
@@ -1,8 +1,8 @@
-import { type PropsWithChildren } from 'react'
-import { ReactQueryProvider } from './react-query/index.tsx'
-import { AuthProvider } from './auth/index.tsx'
+import {type PropsWithChildren} from 'react'
+import {ReactQueryProvider} from './react-query/index.tsx'
+import {AuthProvider} from './auth/index.tsx'
 
-export const Providers = ({ children }: PropsWithChildren) => {
+export const Providers = ({children}: PropsWithChildren) => {
   return (
     <ReactQueryProvider>
       <AuthProvider>{children}</AuthProvider>

--- a/apps/client/app/root.tsx
+++ b/apps/client/app/root.tsx
@@ -1,6 +1,6 @@
-import { cssBundleHref } from '@remix-run/css-bundle'
-import { type PropsWithChildren } from 'react'
-import { json, type LinksFunction } from '@remix-run/node'
+import {cssBundleHref} from '@remix-run/css-bundle'
+import {type PropsWithChildren} from 'react'
+import {json, type LinksFunction} from '@remix-run/node'
 import {
   Links,
   LiveReload,
@@ -12,13 +12,13 @@ import {
   isRouteErrorResponse,
   useLoaderData,
 } from '@remix-run/react'
-import { NODE_ENV } from './constants/index.ts'
+import {NODE_ENV} from './constants/index.ts'
 import tailwindStyles from '@/styles/tailwind.css'
 import globalStyles from '@/styles/global.css'
-import { Toaster } from 'react-hot-toast'
-import { Providers } from './providers/index.tsx'
-import { RouteLoader } from './components/loader/route-loader.tsx'
-import { EnvContext } from './providers/env/index.tsx'
+import {Toaster} from 'react-hot-toast'
+import {Providers} from './providers/index.tsx'
+import {RouteLoader} from './components/loader/route-loader.tsx'
+import {EnvContext} from './providers/env/index.tsx'
 
 export const links: LinksFunction = () => {
   return [
@@ -40,10 +40,10 @@ export const links: LinksFunction = () => {
     //   sizes: '16x16',
     //   href: '/favicons/favicon-16x16.png',
     // },
-    { rel: 'icon', href: '/favicon.ico' },
-    { rel: 'stylesheet', href: tailwindStyles },
-    { rel: 'stylesheet', href: globalStyles },
-    ...(cssBundleHref ? [{ rel: 'stylesheet', href: cssBundleHref }] : []),
+    {rel: 'icon', href: '/favicon.ico'},
+    {rel: 'stylesheet', href: tailwindStyles},
+    {rel: 'stylesheet', href: globalStyles},
+    ...(cssBundleHref ? [{rel: 'stylesheet', href: cssBundleHref}] : []),
   ]
 }
 
@@ -69,7 +69,7 @@ export default function App() {
   )
 }
 
-function Document({ children }: PropsWithChildren) {
+function Document({children}: PropsWithChildren) {
   const data = useLoaderData<typeof loader>()
 
   return (
@@ -82,11 +82,13 @@ function Document({ children }: PropsWithChildren) {
         <Links />
       </head>
       <body>
-        <EnvContext.Provider value={{
-          BUCKET: data.ENV.BUCKET!,
-          MFONI_GOOGLE_AUTH_CLIENT_ID: data.ENV.MFONI_GOOGLE_AUTH_CLIENT_ID!,
-          FACEBOOK_APP_ID: data.ENV.FACEBOOK_APP_ID!,
-        }}>
+        <EnvContext.Provider
+          value={{
+            BUCKET: data.ENV.BUCKET!,
+            MFONI_GOOGLE_AUTH_CLIENT_ID: data.ENV.MFONI_GOOGLE_AUTH_CLIENT_ID!,
+            FACEBOOK_APP_ID: data.ENV.FACEBOOK_APP_ID!,
+          }}
+        >
           {children}
           <Toaster position="bottom-center" />
           <ScrollRestoration />
@@ -96,11 +98,14 @@ function Document({ children }: PropsWithChildren) {
             defer
             data-nscript="afterInteractive"
           />
-          <script type="text/javascript" src="https://sdk.dev.metric.africa/v1" />
+          <script
+            type="text/javascript"
+            src="https://sdk.dev.metric.africa/v1"
+          />
           <script
             dangerouslySetInnerHTML={{
               __html: `window.ENV = ${JSON.stringify({
-                'API_ADDRESS': data.ENV.API_ADDRESS,
+                API_ADDRESS: data.ENV.API_ADDRESS,
               })}`,
             }}
           />

--- a/apps/client/app/routes/auth._index.ts
+++ b/apps/client/app/routes/auth._index.ts
@@ -8,11 +8,4 @@ export const meta: MetaFunction = () => {
   ]
 }
 
-export function loader() {
-  return {
-    MFONI_GOOGLE_AUTH_CLIENT_ID: process.env.MFONI_GOOGLE_AUTH_CLIENT_ID,
-    FACEBOOK_APP_ID: process.env.FACEBOOK_APP_ID,
-  }
-}
-
 export default LoginModule

--- a/apps/client/types/global.d.ts
+++ b/apps/client/types/global.d.ts
@@ -21,7 +21,12 @@ declare global {
     ENV: {
       API_ADDRESS: string
       BUCKET: string
+      FACEBOOK_APP_ID: string
+      MFONI_GOOGLE_AUTH_CLIENT_ID: string
     }
+    fbAsyncInit: any
+    FB: any
+    google: any
   }
 }
 


### PR DESCRIPTION
we can now use `useEnvContext` to access envs instead of `window.ENV`. Old method injects env into html which can be seen in developer console