### PR TITLE
chore: update node version lock

### DIFF
--- a/apps/client/.nvmrc
+++ b/apps/client/.nvmrc
@@ -1,1 +1,1 @@
-lts/hydrogen
+lts/iron

--- a/apps/client/package.json
+++ b/apps/client/package.json
@@ -6,7 +6,7 @@
   "description": "Where all users interact with the system.",
   "type": "module",
   "engines": {
-    "node": "18",
+    "node": ">=18",
     "npm": ">=8"
   },
   "scripts": {


### PR DESCRIPTION
## PR Name or Description

update node version lock

## Overview

Make sure anyone on node version 18 and newer can install packages.

## Detailed Technical Change

- Devs with node version > 18 are not able to install a package

## Testing Approach & Result

- Install node 20.
- You should be able to run app

## Related Work

N/A

## Documentation

N/A
