### PR TITLE
fix: infinite redirect

### DIFF
--- a/apps/client/app/root.tsx
+++ b/apps/client/app/root.tsx
@@ -82,14 +82,15 @@ export async function loader(args: LoaderFunctionArgs) {
 						url.pathname !== PAGES.AUTHENTICATED_PAGES.ONBOARDING
 					) {
 						return redirect(
-							`${
-								PAGES.AUTHENTICATED_PAGES.ONBOARDING
+							`${PAGES.AUTHENTICATED_PAGES.ONBOARDING
 							}?return_to=${getFullUrlPath(url)}`,
 						)
 					}
 				}
 			} catch (e: unknown) {
-				return redirect(`${PAGES.LOGIN}?return_to=${getFullUrlPath(url)}`)
+				if (url.pathname !== PAGES.LOGIN) {
+					return redirect(`${PAGES.LOGIN}?return_to=${getFullUrlPath(url)}`)
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## PR Name or Description

Fix inifinite redirects

## Overview

App used to infinitely redirect to auth page when api fails to respond - Happens when a user is already logged in.

## Detailed Technical Change

Updated `root.tsx` to fix this

## Testing Approach & Result

- Log in and remove api URL from env
- Prior to this change, APP is rerender
- now, app logs you out successfully.

## Related Work

N/A

## Documentation

N/A
