### PR TITLE
feat: Explore Sections API

### DIFF
--- a/services/main/Configurations/AppConstants.cs
+++ b/services/main/Configurations/AppConstants.cs
@@ -18,6 +18,7 @@ public class AppConstants
     public string ContentDownloadCollection { get; init; } = "content_downloads";
     public string CreatorApplicatonCollection { get; init; } = "creator_applications";
     public string CreatorCollection { get; init; } = "creators";
+    public string ExploreSectionCollection { get; init; } = "explore_sections";
     public string TagCollection { get; init; } = "tags";
     public string TagContentCollection { get; init; } = "tag_contents";
     public string WaitlistCollection { get; init; } = "waitlists";

--- a/services/main/Configurations/CacheProvider.cs
+++ b/services/main/Configurations/CacheProvider.cs
@@ -17,6 +17,7 @@ public class CacheProvider
         { "collections", "collections" },
         { "contents", "contents" },
         { "tags", "tags" },
+        { "explore", "explore" },
 
         { "creators", "creators" },
 

--- a/services/main/Controllers/ExploreSection.cs
+++ b/services/main/Controllers/ExploreSection.cs
@@ -1,0 +1,176 @@
+
+using System.Net;
+using System.Security.Claims;
+using main.Domains;
+using main.DTOs;
+using main.Lib;
+using main.Middlewares;
+using main.Transformations;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.OpenApi.Any;
+
+namespace main.Controllers;
+
+[ApiController]
+[Route("api/v1/explore")]
+public class ExploreSectionController : ControllerBase
+{
+    private readonly ILogger<ExploreSectionController> _logger;
+    private readonly ExploreSectionService _exploreSectionService;
+    private readonly ExploreSectionTransformer _exploreSectionTransformer;
+
+    public ExploreSectionController(
+        ILogger<ExploreSectionController> logger,
+        ExploreSectionService exploreSectionService,
+        ExploreSectionTransformer exploreSectionTransformer
+    )
+    {
+        _logger = logger;
+        _exploreSectionService = exploreSectionService;
+        _exploreSectionTransformer = exploreSectionTransformer;
+    }
+
+    [Authorize(Policy = "Admin")]
+    [HttpPost()]
+    public async Task<ActionResult> SaveSection(
+        [FromBody] DTOs.CreateExploreSectionInput input
+    )
+    {
+        try
+        {
+            var currentAdmin = CurrentAdmin.GetCurrentAdmin(
+                HttpContext.User.Identity as ClaimsIdentity
+            );
+            var exploreSection = await _exploreSectionService.Create(
+                new Domains.CreateExploreSection
+                {
+                    Title = input.Title,
+                    Endpoint = input.Endpoint,
+                    Type = input.Type,
+                    EnsureAuth = input.EnsureAuth,
+                    SeeMorePathname = input.SeeMorePathname,
+                    CreatedById = currentAdmin.Id,
+                    Visibility = input.Visibility
+                }
+            );
+
+            return new ObjectResult(
+                new GetEntityResponse<OutputExploreSection>(
+                    _exploreSectionTransformer.Transform(exploreSection),
+                    null
+                ).Result()
+            )
+            {
+                StatusCode = StatusCodes.Status201Created
+            };
+        }
+        catch (HttpRequestException e)
+        {
+            var statusCode = HttpStatusCode.BadRequest;
+            if (e.StatusCode != null)
+            {
+                statusCode = (HttpStatusCode)e.StatusCode;
+            }
+
+            return new ObjectResult(new GetEntityResponse<AnyType?>(null, e.Message).Result()) { StatusCode = (int)statusCode };
+        }
+        catch (Exception e)
+        {
+            _logger.LogError($"Failed to save explore section entry into database. Exception: {e}");
+            SentrySdk.ConfigureScope(scope =>
+            {
+                scope.SetTags(new Dictionary<string, string>
+                {
+                    {"action", "Create Explore Section"},
+                    {"userId", CurrentAdmin.GetCurrentAdmin(HttpContext.User.Identity as ClaimsIdentity).Id},
+                    {"body", StringLib.SafeString(input.ToString())},
+                });
+                SentrySdk.CaptureException(e);
+            });
+            return new StatusCodeResult(500);
+        }
+    }
+
+    /// <summary>
+    /// To retrieve explore sections
+    /// </summary>
+    /// <param name="populate">Comma separated values to populate fields</param>
+    /// <param name="page">The page to be navigated to</param>
+    /// <param name="pageSize">The number of items on a page</param>
+    /// <param name="sort">To sort response data either by `asc` or `desc`</param>
+    /// <param name="sortBy">What field to sort by.</param>
+    /// <response code="200">Explore Sections retrieved successfully</response>
+    /// <response code="500">An unexpected error occured</response>
+    [HttpGet]
+    [ProducesResponseType(
+        StatusCodes.Status200OK,
+        Type = typeof(ApiEntityResponse<EntityWithPagination<OutputExploreSection>>)
+    )]
+    [ProducesResponseType(
+        StatusCodes.Status500InternalServerError,
+        Type = typeof(StatusCodeResult)
+    )]
+    public async Task<IActionResult> GetAll(
+        [FromQuery] int? page,
+        [FromQuery] int? pageSize,
+        [FromQuery] string? sort,
+        [FromQuery] string populate = "",
+        [FromQuery] string sortBy = "created_at"
+    )
+    {
+        try
+        {
+            _logger.LogInformation("Getting explore sections");
+            var queryFilter = HttpLib.GenerateFilterQuery<Models.ExploreSection>(page, pageSize, sort, sortBy, populate);
+            var sections = await _exploreSectionService.GetSections(queryFilter);
+
+            long count = await _exploreSectionService.CountSections();
+
+            var outSection = new List<OutputExploreSection>();
+            foreach (var content in sections)
+            {
+                outSection.Add(_exploreSectionTransformer.Transform(content, populate: queryFilter.Populate));
+            }
+
+            var response = HttpLib.GeneratePagination(
+                outSection,
+                count,
+                queryFilter
+            );
+            return new ObjectResult(
+                new GetEntityResponse<EntityWithPagination<OutputExploreSection>>(response, null).Result()
+            )
+            {
+                StatusCode = StatusCodes.Status200OK
+            };
+        }
+        catch (HttpRequestException e)
+        {
+            var statusCode = HttpStatusCode.BadRequest;
+            if (e.StatusCode != null)
+            {
+                statusCode = (HttpStatusCode)e.StatusCode;
+            }
+
+            return new ObjectResult(new GetEntityResponse<AnyType?>(null, e.Message).Result()) { StatusCode = (int)statusCode };
+        }
+        catch (Exception e)
+        {
+            _logger.LogError($"Failed to fetch explore section entry. Exception: {e}");
+            SentrySdk.ConfigureScope(scope =>
+          {
+              scope.SetTags(new Dictionary<string, string>
+              {
+                    {"action", "Get Explore Sections"},
+                    {"populate", populate},
+                    {"page", StringLib.SafeString(page.ToString())},
+                    {"pageSize", StringLib.SafeString(pageSize.ToString())},
+              });
+              SentrySdk.CaptureException(e);
+          });
+            return new StatusCodeResult(500);
+        }
+    }
+
+}

--- a/services/main/DTOs/ExploreSection.cs
+++ b/services/main/DTOs/ExploreSection.cs
@@ -1,0 +1,46 @@
+
+using System.ComponentModel.DataAnnotations;
+
+namespace main.DTOs;
+
+public class CreateExploreSectionInput
+{
+    /// <summary>
+    /// Type of the section
+    /// </summary>
+    /// <example>TAG | CONTENT | COLLECTION | CREATOR</example>
+    [Required]
+    public required string Type { get; set; }
+
+    /// <summary>
+    /// Endpoint that should be called to fetch data
+    /// </summary>
+    /// <example>/collections/:collection_slug</example>
+    [Required]
+    public required string Endpoint { get; set; }
+
+    /// <summary>
+    /// Title of the section
+    /// </summary>
+    /// <example>Hello world</example>
+    [Required]
+    public required string Title { get; set; }
+
+    /// <summary>
+    /// Pathname to see more of that section. If null, then there's no registered page for it.
+    /// </summary>
+    /// <example>/explore/collections</example>
+    public string? SeeMorePathname { get; set; }
+
+    /// <summary>
+    /// When this is true, user must be authenticated to see this section
+    /// </summary>
+    /// <example>false</example>
+    public bool? EnsureAuth { get; set; }
+
+    /// <summary>
+    /// When this is PUBLIC, everyone can see this section on the website .
+    /// </summary>
+    /// <example>PUBLIC | PRIVATE</example>
+    public string? Visibility { get; set; }
+}

--- a/services/main/DTOs/OutputExploreSection.cs
+++ b/services/main/DTOs/OutputExploreSection.cs
@@ -1,0 +1,17 @@
+
+namespace main.DTOs;
+
+public class OutputExploreSection
+{
+    public required string Id { get; set; }
+    public required string Visibility { get; set; }
+    public required string Type { get; set; }
+    public required string Endpoint { get; set; }
+    public required string Title { get; set; }
+    public required int Sort { get; set; }
+    public string? SeeMorePathname { get; set; }
+    public required bool EnsureAuth { get; set; }
+    public OutputAdmin? CreatedBy { get; set; }
+    public required DateTime CreatedAt { get; set; }
+    public required DateTime UpdatedAt { get; set; }
+}

--- a/services/main/Domains/Collection/CollectionService.cs
+++ b/services/main/Domains/Collection/CollectionService.cs
@@ -231,7 +231,7 @@ public class CollectionService
     public void BootstrapCollections()
     {
         _logger.LogInformation("Bootsrapping collections");
-        string[] collections = { "Featured::Contents", "Featured::Tags", "Featured::Collections" };
+        string[] collections = { "Featured::Contents", "Featured::Tags", "Featured::Collections", "Trending::Collections", "Popular::Tags", "Featured::Creators" };
         string collectionDescription = "Carefully curated collection of contents for your viewing pleasure by our team of experts at mfoni";
 
         foreach (var collection in collections)

--- a/services/main/Domains/Explore/ExploreSectionService.cs
+++ b/services/main/Domains/Explore/ExploreSectionService.cs
@@ -1,0 +1,182 @@
+using main.Configuratons;
+using main.Lib;
+using main.Models;
+using Microsoft.Extensions.Options;
+using MongoDB.Driver;
+
+namespace main.Domains;
+
+public class ExploreSectionService
+{
+    private readonly ILogger<ExploreSectionService> _logger;
+    private readonly IMongoCollection<Models.ExploreSection> _exploreSectionsCollection;
+    private readonly CacheProvider _cacheProvider;
+
+    public ExploreSectionService(
+       ILogger<ExploreSectionService> logger,
+       DatabaseSettings databaseConfig,
+       IOptions<AppConstants> appConstants,
+       CacheProvider cacheProvider
+   )
+    {
+        _logger = logger;
+
+        var database = databaseConfig.Database;
+
+        _exploreSectionsCollection = database.GetCollection<Models.ExploreSection>(appConstants.Value.ExploreSectionCollection);
+
+        _cacheProvider = cacheProvider;
+
+        _logger.LogDebug("ExploreSectionService initialized");
+    }
+
+    public async Task<Models.ExploreSection> Create(CreateExploreSection input)
+    {
+
+        var oldExploreSection = await _exploreSectionsCollection.Find(exploreSection => exploreSection.Title.ToLower() == input.Title.ToLower()).FirstOrDefaultAsync();
+
+        if (oldExploreSection is not null)
+        {
+            throw new HttpRequestException("ExploreSectionAlreadyExists");
+        }
+
+        var countOfSections = await _exploreSectionsCollection.CountDocumentsAsync(_ => true);
+
+        var exploreSection = new Models.ExploreSection
+        {
+            Endpoint = input.Endpoint,
+            SeeMorePathname = input.SeeMorePathname,
+            Title = input.Title,
+            Type = input.Type,
+            Sort = (int)countOfSections + 1,
+        };
+
+        if (input.EnsureAuth is not null)
+        {
+            exploreSection.EnsureAuth = (bool)input.EnsureAuth;
+        }
+
+        if (input.Visibility is not null)
+        {
+            exploreSection.Visibility = (string)input.Visibility;
+        }
+
+        await _exploreSectionsCollection.InsertOneAsync(exploreSection);
+
+        _ = _cacheProvider.EntityChanged(new[] {
+            $"{CacheProvider.CacheEntities["explore"]}.find*",
+        });
+
+        return exploreSection;
+    }
+
+    public async Task<List<Models.ExploreSection>> GetSections(
+        FilterQuery<Models.ExploreSection> queryFilter
+    )
+    {
+        FilterDefinitionBuilder<Models.ExploreSection> builder = Builders<Models.ExploreSection>.Filter;
+        var filter = builder.Eq(r => r.Visibility, ExploreSectionVisibility.PUBLIC);
+
+        var sections = await _exploreSectionsCollection
+            .Find(filter)
+            .Skip(queryFilter.Skip)
+            .Limit(queryFilter.Limit)
+            .Sort(queryFilter.Sort)
+            .ToListAsync();
+
+        return sections ?? [];
+    }
+
+    public async Task<long> CountSections()
+    {
+        FilterDefinitionBuilder<Models.ExploreSection> builder = Builders<Models.ExploreSection>.Filter;
+        var filter = builder.Eq(r => r.Visibility, ExploreSectionVisibility.PUBLIC);
+        var count = await _exploreSectionsCollection.CountDocumentsAsync(filter);
+
+        return count;
+    }
+
+    public async Task ResolveExploreSection(CreateExploreSection input)
+    {
+        var oldExploreSection = await _exploreSectionsCollection.Find(exploreSection => exploreSection.Title.ToLower() == input.Title.ToLower()).FirstOrDefaultAsync();
+
+        if (oldExploreSection is not null)
+        {
+            return;
+        }
+
+        await Create(input);
+    }
+
+    public async Task BootstrapExploreSections()
+    {
+        _logger.LogInformation("Bootsrapping explore sections now!");
+        CreateExploreSection[] sections = {
+            new CreateExploreSection
+            {
+                Title = "Featured Images",
+                Endpoint = "/api/v1/collections/featured_contents",
+                Type = ExploreSectionType.CONTENT,
+                SeeMorePathname = "/explore/contents?type=image&featured=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Featured Collections",
+                Endpoint = "/api/v1/collections/featured_collections",
+                Type = ExploreSectionType.COLLECTION,
+                SeeMorePathname = "/explore/collections?featured=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Featured Tags",
+                Endpoint = "/api/v1/collections/featured_tags",
+                Type = ExploreSectionType.TAG,
+                SeeMorePathname = "/explore/tags?featured=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Featured Creators",
+                Endpoint = "/api/v1/collections/featured_creators",
+                Type = ExploreSectionType.CREATOR,
+                SeeMorePathname = "/explore/creators?featured=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Trending Collections",
+                Endpoint = "/api/v1/collections/trending_collections",
+                Type = ExploreSectionType.COLLECTION,
+                SeeMorePathname = "/explore/collections?trending=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Popular Tags",
+                Endpoint = "/api/v1/collections/popular_tags",
+                Type = ExploreSectionType.TAG,
+                SeeMorePathname = "/explore/tags?popular=true",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+            new CreateExploreSection
+            {
+                Title = "Your Followings",
+                Endpoint = "/api/v1/followings",
+                Type = ExploreSectionType.CREATOR,
+                EnsureAuth = true,
+                SeeMorePathname = "/account/followings",
+                Visibility = ExploreSectionVisibility.PUBLIC,
+            },
+
+        };
+
+        foreach (var section in sections)
+        {
+            await ResolveExploreSection(section);
+        }
+        _logger.LogInformation("ExploreSections Bootstrapped now!");
+
+    }
+}

--- a/services/main/Domains/Explore/dto.cs
+++ b/services/main/Domains/Explore/dto.cs
@@ -1,0 +1,12 @@
+namespace main.Domains;
+
+public class CreateExploreSection
+{
+    public required string Type { get; set; }
+    public required string Endpoint { get; set; }
+    public required string Title { get; set; }
+    public string? SeeMorePathname { get; set; }
+    public bool? EnsureAuth { get; set; }
+    public string? Visibility { get; set; }
+    public string? CreatedById { get; set; }
+}

--- a/services/main/HostedServices/StartupService.cs
+++ b/services/main/HostedServices/StartupService.cs
@@ -6,17 +6,21 @@ namespace main.HostedServices
     {
         private readonly AdminWalletService _adminWalletService;
         private readonly CollectionService _collectionService;
+        private readonly ExploreSectionService _exploreSectionService;
 
-        public StartUpService(AdminWalletService adminWalletService, CollectionService collectionService)
+        public StartUpService(AdminWalletService adminWalletService, CollectionService collectionService,
+            ExploreSectionService exploreSectionService
+        )
         {
             _adminWalletService = adminWalletService;
             _collectionService = collectionService;
+            _exploreSectionService = exploreSectionService;
         }
-
         public async Task StartAsync(CancellationToken cancellationToken)
         {
             await _adminWalletService.BootsrapAdminWallet();
             _collectionService.BootstrapCollections();
+            await _exploreSectionService.BootstrapExploreSections();
         }
 
         public Task StopAsync(CancellationToken cancellationToken)

--- a/services/main/Lib/PopulateKeys.cs
+++ b/services/main/Lib/PopulateKeys.cs
@@ -9,6 +9,7 @@ public class PopulateKeys
     public static readonly string SUBSCRIPTION = "subscription";
     public static readonly string COLLECTION_CREATED_BY = "collection.createdBy";
     public static readonly string CONTENT_LIKE_CREATED_BY = "contentLike.createdBy";
+    public static readonly string EXPLORE_SECTION_CREATED_BY = "exploreSection.createdBy";
     public static readonly string COLLECTION = "collection";
     public static readonly string CONTENT = "content";
     public static readonly string CONTENT_TAGS = "content.tags";

--- a/services/main/Models/CollectionContent.cs
+++ b/services/main/Models/CollectionContent.cs
@@ -5,6 +5,7 @@ namespace main.Models;
 
 public static class CollectionContentType
 {
+    public static readonly string CREATOR = "CREATOR";
     public static readonly string TAG = "TAG";
     public static readonly string CONTENT = "CONTENT";
     public static readonly string COLLECTION = "COLLECTION";
@@ -30,6 +31,10 @@ public class CollectionContent
     [BsonElement("content_id")]
     [BsonRepresentation(BsonType.ObjectId)]
     public string? ContentId { get; set; }
+
+    [BsonElement("creator_id")]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string? CreatorId { get; set; }
 
     [BsonElement("child_collection_id")]
     [BsonRepresentation(BsonType.ObjectId)]

--- a/services/main/Models/ExploreSection.cs
+++ b/services/main/Models/ExploreSection.cs
@@ -1,0 +1,55 @@
+using MongoDB.Bson;
+using MongoDB.Bson.Serialization.Attributes;
+
+namespace main.Models;
+
+public static class ExploreSectionType
+{
+    public static readonly string TAG = "TAG";
+    public static readonly string COLLECTION = "COLLECTION";
+    public static readonly string CREATOR = "CREATOR";
+    public static readonly string CONTENT = "CONTENT";
+}
+
+public static class ExploreSectionVisibility
+{
+    public static readonly string PUBLIC = "PUBLIC";
+    public static readonly string PRIVATE = "PRIVATE";
+}
+
+public class ExploreSection
+{
+    [BsonId]
+    [BsonRepresentation(BsonType.ObjectId)]
+    public string Id { get; set; } = null!;
+
+    [BsonElement("visibility")]
+    public string Visibility { get; set; } = ExploreSectionVisibility.PRIVATE;
+
+    [BsonElement("type")]
+    public required string Type { get; set; }
+
+    [BsonElement("endpoint")]
+    public required string Endpoint { get; set; }
+
+    [BsonElement("title")]
+    public required string Title { get; set; }
+
+    [BsonElement("sort")]
+    public required int Sort { get; set; }
+
+    [BsonElement("see_more_pathname")]
+    public string? SeeMorePathname { get; set; }
+
+    [BsonElement("ensure_auth")]
+    public bool EnsureAuth { get; set; } = false;
+
+    [BsonElement("created_by_id")]
+    public string? CreatedById { get; set; }
+
+    [BsonElement("created_at")]
+    public DateTime CreatedAt { get; init; } = DateTime.UtcNow;
+
+    [BsonElement("updated_at")]
+    public DateTime UpdatedAt { get; set; } = DateTime.UtcNow;
+}

--- a/services/main/Program.cs
+++ b/services/main/Program.cs
@@ -155,6 +155,8 @@ builder.Services.AddSingleton<CollectionService>();
 builder.Services.AddSingleton<CollectionContentService>();
 builder.Services.AddSingleton<ContentLikeService>();
 
+builder.Services.AddSingleton<ExploreSectionService>();
+
 // indexing content services
 builder.Services.AddSingleton<IndexContent>();
 builder.Services.AddSingleton<ProcessIndexContent>();
@@ -176,6 +178,7 @@ builder.Services.AddSingleton<CollectionContentTransformer>();
 builder.Services.AddSingleton<TagTransformer>();
 builder.Services.AddSingleton<ContentLikeTransformer>();
 builder.Services.AddSingleton<TagContentTransformer>();
+builder.Services.AddSingleton<ExploreSectionTransformer>();
 
 // hosted services.
 builder.Services.AddHostedService<ConsumerHostedService>();

--- a/services/main/Transformations/ExploreSectionTransformer.cs
+++ b/services/main/Transformations/ExploreSectionTransformer.cs
@@ -1,0 +1,54 @@
+
+
+using main.Domains;
+using main.DTOs;
+using main.Models;
+
+namespace main.Transformations;
+
+public class ExploreSectionTransformer
+{
+    private readonly ExploreSectionService _exploreSectionService;
+    private readonly AdminService _adminService;
+    private readonly AdminTransformer _adminTransformer;
+    public ExploreSectionTransformer(
+        ExploreSectionService exploreSectionService,
+        AdminService adminService,
+        AdminTransformer adminTransformer
+    )
+    {
+        _exploreSectionService = exploreSectionService;
+        _adminService = adminService;
+        _adminTransformer = adminTransformer;
+    }
+
+    public OutputExploreSection Transform(ExploreSection exploreSection, string[]? populate = null)
+    {
+
+        populate ??= Array.Empty<string>();
+
+        OutputAdmin? outputCreatedByAdmin = null;
+        if (exploreSection.CreatedById is not null && populate.Any(p => p.Contains(PopulateKeys.EXPLORE_SECTION_CREATED_BY)))
+        {
+            var createdBy = _adminService.GetAdminById(exploreSection.CreatedById);
+            if (createdBy is not null)
+            {
+                outputCreatedByAdmin = _adminTransformer.Transform(createdBy, populate);
+            }
+        }
+
+        return new OutputExploreSection
+        {
+            Id = exploreSection.Id,
+            Visibility = exploreSection.Visibility,
+            Endpoint = exploreSection.Endpoint,
+            Sort = exploreSection.Sort,
+            Title = exploreSection.Title,
+            Type = exploreSection.Type,
+            EnsureAuth = exploreSection.EnsureAuth,
+            CreatedBy = outputCreatedByAdmin,
+            CreatedAt = exploreSection.CreatedAt,
+            UpdatedAt = exploreSection.UpdatedAt,
+        };
+    }
+}


### PR DESCRIPTION
## PR Name or Description

Explore Sections API Feature

## Overview

Explore sections on website should be dynamic. Admins controls what should be seen and in what order.

## Detailed Technical Change

Model:
```
- id // auto generated
- visibility: public | private
- Type: tag, collection, creator, content.
- endpoint: string // api endpoint to make request to.
- sort: number //  in what order users will see the sections on the explore page.
- title // Main description of a section
- seeMorePathname?: nullable // reroutes you to the single page with more of that contents
- ensureAuth: bool //you'll need to be authenticated to see it.
```

## Testing Approach & Result

- Visit `/explore` page

## Related Work

N/A

## Documentation

N/A
