### PR TITLE
feat: added impl to persist changes to search service

### DIFF
--- a/services/main/Configurations/AppConstants.cs
+++ b/services/main/Configurations/AppConstants.cs
@@ -30,6 +30,7 @@ public class AppConstants
     public string BucketName { get; set; } = null!;
     public string AWSRekognitionCollection { get; set; } = null!;
     public string ProcessImageQueueName { get; set; } = null!;
+    public string ProcessTextualSearchQueueName { get; set; } = null!;
     public string UserJwtSecret { get; set; } = null!;
     public string AdminJwtSecret { get; set; } = null!;
     public string JwtIssuer { get; set; } = null!;

--- a/services/main/Domains/Content/IndexContentService.cs
+++ b/services/main/Domains/Content/IndexContentService.cs
@@ -140,28 +140,14 @@ public class IndexContent
         });
 
         // push to queue for image processing
-        using var channel = _rabbitMqChannel.CreateModel();
-
-        channel.QueueDeclare(
-            queue: _appConstantsConfiguration.ProcessImageQueueName,
-            durable: true,
-            exclusive: false,
-            autoDelete: false,
-            arguments: null
-        );
+        var processContentQueueHelper = new QueueHelper(_rabbitMqChannel, _appConstantsConfiguration.ProcessImageQueueName);
 
         contents.ToList().ForEach(content =>
         {
             _logger.LogInformation($"Sending message to queue: {content.Id}", content.Id);
             string message = content.Id;
-            var body = Encoding.UTF8.GetBytes(message);
 
-            channel.BasicPublish(
-                exchange: "",
-                routingKey: _appConstantsConfiguration.ProcessImageQueueName,
-                basicProperties: null,
-                body: body
-            );
+            processContentQueueHelper.PublishMessage(message);
         });
 
         return contents;

--- a/services/main/Domains/Content/ProcessIndexContentService.cs
+++ b/services/main/Domains/Content/ProcessIndexContentService.cs
@@ -8,6 +8,7 @@ using Amazon.Rekognition;
 using Amazon.Runtime;
 using main.Lib;
 using Amazon.Rekognition.Model;
+using Newtonsoft.Json;
 
 namespace main.Domains;
 
@@ -127,6 +128,19 @@ public class ProcessIndexContent
 
                 await SaveRekognitionContent(content.Id, faces);
             }
+
+            // index for textual search capabilities
+            var processTextualSearchQueueHelper = new QueueHelper(
+                _rabbitMqChannel, _appConstantsConfiguration.ProcessTextualSearchQueueName
+            );
+
+            var message = new
+            {
+                type = "CREATE",
+                content_id = content.Id
+            };
+
+            processTextualSearchQueueHelper.PublishMessage(JsonConvert.SerializeObject(message));
         }
         catch (HttpRequestException ex)
         {

--- a/services/main/Lib/QueueHelper.cs
+++ b/services/main/Lib/QueueHelper.cs
@@ -1,0 +1,46 @@
+using System.Text;
+using RabbitMQ.Client;
+
+namespace main.Lib;
+
+public class PublishMessageInput
+{
+    public required RabbitMQ.Client.IConnection RabbitMqChannel { get; set; }
+    public required string Message { get; set; }
+    public required string QueueName { get; set; }
+}
+
+public class QueueHelper
+{
+    private readonly string _queueName;
+    private readonly RabbitMQ.Client.IModel _rabbitMqModel;
+
+    public QueueHelper(RabbitMQ.Client.IConnection rabbitMqChannel, string queueName)
+    {
+        var rabbitMqModel = rabbitMqChannel.CreateModel();
+
+        // create queue if it does not exist.
+        rabbitMqModel.QueueDeclare(
+            queue: queueName,
+            durable: true,
+            exclusive: false,
+            autoDelete: false,
+            arguments: null
+        );
+
+        _rabbitMqModel = rabbitMqModel;
+        _queueName = queueName;
+    }
+
+    public void PublishMessage(string message)
+    {
+        var body = Encoding.UTF8.GetBytes(message);
+
+        _rabbitMqModel.BasicPublish(
+            exchange: "",
+            routingKey: _queueName,
+            basicProperties: null,
+            body: body
+        );
+    }
+}

--- a/services/search/internal/processors/content.go
+++ b/services/search/internal/processors/content.go
@@ -175,6 +175,11 @@ func ProcessMessage(imessage []byte, svcs services.Services) error {
 		if updateErr != nil {
 			return updateErr
 		}
+	/**
+	* TODO: handle case where a tag was updated/deleted.
+	* This means we have to update all contents with that tag.
+	 */
+
 	case "UPDATE_COLLECTIONS":
 		contentCollections, contentCollectionsErr := svcs.ContentService.
 			FindCollections(context.Background(), message.ContentID)
@@ -187,6 +192,11 @@ func ProcessMessage(imessage []byte, svcs services.Services) error {
 		if updateErr != nil {
 			return updateErr
 		}
+
+	/**
+	* TODO: handle case where a collection was updated/deleted.
+	* This means we have to update all contents with that collection.
+	 */
 	case "DELETE":
 		_, deleteErr := svcs.ContentService.Purge(context.Background(), message.ContentID)
 


### PR DESCRIPTION
## PR Name or Description

feat: added impl to persist changes to search service

## Overview

When users add/update contents, those details are persisted into the search service

## Detailed Technical Change

- Created a utility to easily publish messages to the queue handling textual search indexing

## Testing Approach & Result

- Upload new content. You should be able to search after indexing is completed
- Also, after updating deets on the content, you should be able to search those updates

## Related Work

N/A

## Documentation

N/A
